### PR TITLE
fix(security): add authorization checks to conversation endpoints

### DIFF
--- a/app/Http/Controllers/Conversation/ConversationController.php
+++ b/app/Http/Controllers/Conversation/ConversationController.php
@@ -31,8 +31,10 @@ class ConversationController extends Controller
 
     public function show(Conversation $conversation, Request $request): JsonResponse
     {
-        // TODO: Add authorization
-        // $this->authorize('show', $conversation);
+        // Verify user is a participant in the conversation
+        if (!$conversation->users->contains(auth()->id())) {
+            abort(403, 'You are not authorized to view this conversation.');
+        }
 
         $conversation->load(['users', 'messages', 'messages.user']);
         $conversation->loadCount('messages');
@@ -56,6 +58,11 @@ class ConversationController extends Controller
      */
     public function markAsRead(Conversation $conversation): JsonResponse
     {
+        // Verify user is a participant in the conversation
+        if (!$conversation->users->contains(auth()->id())) {
+            abort(403, 'You are not authorized to access this conversation.');
+        }
+
         auth()->user()->conversations()->updateExistingPivot($conversation->id, [
             'read_at' => now(),
         ]);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -51,7 +51,7 @@ class UserController extends Controller
         }
 
         return User::where('id', '!=', auth()->id())
-            ->where(DB::raw('LOWER(username)'), 'LIKE', '%'.Str::lower($q).'%')
+            ->whereRaw('LOWER(username) LIKE ?', ['%' . Str::lower($q) . '%'])
             ->get(['id', 'username', 'email'])
             ->map(function ($user) {
                 return [


### PR DESCRIPTION
- Add participant verification in ConversationController::show()
- Add participant verification in ConversationController::markAsRead()
- Prevents unauthorized access to private conversations
- Closes critical security vulnerability

BREAKING CHANGE: Unauthorized users will now receive 403 instead of viewing conversations

Note: Audit documentation available separately outside codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation access is now restricted to participants only; non-participants will receive an access error when attempting to view or modify conversations.

* **Refactor**
  * Improved query implementation for user search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->