### PR TITLE
cleanup: Remove commented debug statements from controllers

### DIFF
--- a/app/Http/Controllers/CommonController.php
+++ b/app/Http/Controllers/CommonController.php
@@ -11,21 +11,13 @@ class CommonController extends Controller
 {
     public function getItems(Request $request)
     {
-//        dd($request);
-        // Get the foreign key field and its value from the request
         $foreignKeyField = $request->get('foreign_key');
-//        $foreignKeyValue = $request->input('value');
-
-//        dd($foreignKeyField);
 
         if (!$foreignKeyField) {
             return response()->json(['error' => __('messages.common.invalid_params')], 400);
         }
 
         if ($foreignKeyField === 'taxonomy') {
-//            dd('taxonmoy');
-//            dd(TaxonomyHelper::getTaxonomy());
-
             $items = TaxonomyHelper::getTaxonomy();
 
             return response()->json($items);
@@ -33,7 +25,6 @@ class CommonController extends Controller
 
         // Extract the related model name from the foreign key (e.g., 'user_id' -> 'User')
         if (str_ends_with($foreignKeyField, '_id')) {
-            //$relatedModelName = Str::studly(str_replace('_id', '', $foreignKeyField));
             $fieldWithoutId = str_replace('_id', '', $foreignKeyField);
 
             // Split the field based on underscores to determine namespace and model
@@ -44,31 +35,23 @@ class CommonController extends Controller
                 $relatedModelClass = "App\\Models\\$relatedModelName";
             } else {
                 // Multiple parts (e.g., event_type_id -> App\Models\Event\Type)
-                $namespacePart = ucfirst($fieldParts[0]); // First part, used for namespace
+                $namespacePart = ucfirst($fieldParts[0]);
                 $relatedModelName = Str::studly(str_replace('_id', '', $foreignKeyField));
                 if ($namespacePart === 'Tag') {
                     $relatedModelName = Str::replaceFirst($namespacePart, '', $relatedModelName);
                 }
-//                $modelNamePart = Str::studly(implode('_', array_slice($fieldParts, 1))); // Remaining parts combined, used for model name
                 $relatedModelClass = "App\\Models\\$namespacePart\\$relatedModelName";
             }
         } else {
             return response()->json(['error' => __('messages.common.invalid_foreign_key')], 400);
         }
 
-//        dd($relatedModelClass);
-
-        // Construct the related model class name dynamically
-//        $relatedModelClass = "App\\Models\\" . $relatedModelName;
-
         // Check if the related model class exists
         if (!class_exists($relatedModelClass)) {
-//            dd($relatedModelClass);
             return response()->json(['error' => __('messages.common.model_not_found')], 404);
         }
 
         try {
-            // Query the related model for the given ID value
             $items = $relatedModelClass::all();
 
             return response()->json($items);

--- a/app/Http/Controllers/DataTable/DataTableController.php
+++ b/app/Http/Controllers/DataTable/DataTableController.php
@@ -119,9 +119,7 @@ abstract class DataTableController extends Controller
         try {
             //if model has appended attributes and append attributes  not in displayable colimns...forget them
             $forget = array_diff($this->getAppends(), $this->getDisplayableColumns());
-//            dd($request);
             $pagination = (int) $request->get('itemsPerPage') <= 0 ? (int) $request->get('itemsLength') : (int) $request->get('itemsPerPage');
-//            dd((int)$request->get('itemsLength'));
 
             if ($pagination === 0) {
                 return $builder->orderBy('id', 'asc')->get()->makeHidden($forget);

--- a/app/Http/Controllers/DataTable/EventController.php
+++ b/app/Http/Controllers/DataTable/EventController.php
@@ -17,7 +17,6 @@ class EventController extends DataTableController
 
     public function store(Request $request)
     {
-//                dd($request);
         $event = auth()->user()->events()->create($request->only($this->getUpdatableColumns()));
 
         if ($request->get('parent')) {
@@ -30,7 +29,6 @@ class EventController extends DataTableController
         if ($request->get('taxonomy') && $request->get('categories')) {
             $taxonomy = $request->get('taxonomy');
             $taxonomy = $taxonomy['taxonomy'];
-            //            dd('hm');
             $event->addCategories($request->get('categories'), $taxonomy);
         }
 
@@ -41,7 +39,6 @@ class EventController extends DataTableController
 
     public function update($id, Request $request)
     {
-        //            dd($id, $request);
         $event = Event::find($id);
         $event->update($request->only($this->getUpdatableColumns()));
 

--- a/app/Http/Controllers/DataTable/EventProfileController.php
+++ b/app/Http/Controllers/DataTable/EventProfileController.php
@@ -18,9 +18,7 @@ class EventProfileController extends DataTableController
 
     public function store(Request $request)
     {
-//                dd($request);
         $user = auth()->user();
-//        dd($user);
         $profile = $request->only($this->getUpdatableColumns());
         $profile['user_id'] = $user->id;
         $eventProfile = EventProfile::create($profile);
@@ -29,12 +27,9 @@ class EventProfileController extends DataTableController
     public function show($id, Request $request): JsonResponse
     {
         $evnetProfile = EventProfile::find($id);
-//        dd($evnetProfile);
 
-//        dd($evnetProfile);
 
         $options = json_decode($evnetProfile->options);
-//        dd($options);
         $evnetProfile->options = $options;
 
         return response()->json(

--- a/app/Http/Controllers/DataTable/EventTypeController.php
+++ b/app/Http/Controllers/DataTable/EventTypeController.php
@@ -17,13 +17,11 @@ class EventTypeController extends DataTableController
 
     public function store(Request $request)
     {
-//                dd($request);
         $eventType = EventType::create($request->only($this->getUpdatableColumns()));
     }
 
     public function update($id, Request $request)
     {
-        //            dd($id, $request);
         $event = EventType::find($id);
         $event->update($request->only($this->getUpdatableColumns()));
 

--- a/app/Http/Controllers/DataTable/PageController.php
+++ b/app/Http/Controllers/DataTable/PageController.php
@@ -17,7 +17,6 @@ class PageController extends DataTableController
 
     public function store(Request $request)
     {
-        //        dd($request);
         $page = auth()->user()->pages()->create($request->only($this->getUpdatableColumns()));
 
         if ($request->get('parent')) {
@@ -30,7 +29,6 @@ class PageController extends DataTableController
         if ($request->get('taxonomy') && $request->get('categories')) {
             $taxonomy = $request->get('taxonomy');
             $taxonomy = $taxonomy['taxonomy'];
-            //            dd('hm');
             $page->addCategories($request->get('categories'), $taxonomy);
         }
 
@@ -41,7 +39,6 @@ class PageController extends DataTableController
 
     public function update($id, Request $request)
     {
-        //            dd($id, $request);
         $page = Page::find($id);
         $page->update($request->only($this->getUpdatableColumns()));
 

--- a/app/Http/Controllers/DataTable/PermissionController.php
+++ b/app/Http/Controllers/DataTable/PermissionController.php
@@ -27,18 +27,15 @@ class PermissionController extends DataTableController
     public function updateRolePermissions(Request $request)
     {
         //Todo make PermissionRequest validation
-        //dd($request);
 
         $roles = collect($request)->groupBy('role')->map(function ($role) {
             return collect($role)->map(function ($item) {
                 return $item['permission'];
             });
         });
-//        dd($roles);
         foreach ($roles as $roleId => $rolePermissions) {
             $role = Role::findById($roleId, 'api');
             $role->syncPermissions($rolePermissions);
-//            dd($rolePermissions);
 //            Permission::findById()
         }
 

--- a/app/Http/Controllers/DataTable/TaxonomyController.php
+++ b/app/Http/Controllers/DataTable/TaxonomyController.php
@@ -21,7 +21,6 @@ class TaxonomyController extends DataTableController
 
     public function update($id, Request $request)
     {
-        //dd($id, $request);
 
         $taxonomy = Taxonomy::find($id);
 

--- a/app/Http/Controllers/DataTable/TermController.php
+++ b/app/Http/Controllers/DataTable/TermController.php
@@ -15,7 +15,6 @@ class TermController extends DataTableController
 
     public function store(Request $request)
     {
-//        dd($request);
         $parent = $request->get('tag_taxonomy_id') ?? 0;
 
         $name = $request->get('name');

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -37,7 +37,6 @@ class EventController extends Controller
     {
         $events = Event::all();
 //        $events = DB::select('select * from events');
-//        dd($events);
         $eventTypes = EventType::all()->keyBy('id');
         $eventsMapped = $events->map(function ($event) use ($eventTypes) {
             if ($event->endDate === null) {
@@ -71,7 +70,6 @@ class EventController extends Controller
 //            ];
 
 //            $eventType = $event->type()->first();
-//            dd($eventTypes[$event->type_id]['color']);
 
             $originDate = [
                 'startDate' => $event->startDate,
@@ -100,7 +98,6 @@ class EventController extends Controller
 //                'colorName'       => $eventTypes[$event->type_id]['color']];
         });
 
-        //dd($eventsMapped);
         return response()->json([
             'data' => [
                 'types'  => $eventTypes,
@@ -109,13 +106,10 @@ class EventController extends Controller
 
     public function store(Request $request)
     {
-//                dd($request->all());
-//        dd(request()->get('extendedProps'));
         $this->validate($request, [
             'title' => 'required', //            'email'      => 'required|unique:users,email,'.$id.'|email',
         ]);
 
-        //        dd($request->all());
 
         $event = new Event();
         $event->title = request()->get('title');
@@ -135,7 +129,6 @@ class EventController extends Controller
 //        $event->type = request()->get('type');
 
         if (request()->get('start')) {
-            //dd($date);
             $event->startDate = date('Y-m-d', strtotime(request()->get('start')));
             $event->endDate = date('Y-m-d', strtotime(request()->get('end')));
 
@@ -154,7 +147,6 @@ class EventController extends Controller
         }
 
         if ($date = request()->get('date')) {
-            //dd($date);
             $event->startDate = date('Y-m-d', strtotime($date['date'][0]));
             $event->endDate = date('Y-m-d', strtotime($date['date'][1]));
 
@@ -249,7 +241,6 @@ class EventController extends Controller
         $options = json_decode($eventType->options);
         $answers = [];
         foreach ($options->answers as $value => $answer) {
-//            dd($answer);
             $answers[$answer->key] = $event->answer($answer->key)->get(['username']);
 
 //            $approved[$value] = $event->;
@@ -295,14 +286,12 @@ class EventController extends Controller
         $event->user_id = $user->id;
 
         if ($extendedProps = request()->get('extendedProps')) {
-//            dd($extendedProps);
             $event->event_type_id = $extendedProps['event_type_id'];
         }
 
 //        $event->type = request()->get('type');
 
         if (request()->get('start')) {
-            //dd($date);
             $event->startDate = date('Y-m-d', strtotime(request()->get('start')));
             $event->endDate = date('Y-m-d', strtotime(request()->get('end')));
 
@@ -317,7 +306,6 @@ class EventController extends Controller
         }
 
         if ($date = request()->get('date')) {
-            //dd($date);
             $event->startDate = date('Y-m-d', strtotime($date['date'][0]));
             $event->endDate = date('Y-m-d', strtotime($date['date'][1]));
 
@@ -488,7 +476,6 @@ class EventController extends Controller
 
             return $modified;
         });
-//        dd($eventTypes);
 
         return response()->json([
             'data' => $eventTypeCollection, ]);

--- a/app/Http/Controllers/RelateableController.php
+++ b/app/Http/Controllers/RelateableController.php
@@ -49,7 +49,6 @@ class RelateableController extends Controller
 
     public function relateModels(Request $request)
     {
-//        dd($request->get('data'));
 
         $data = $request->get('data');
 

--- a/app/Http/Controllers/TaxonomyController.php
+++ b/app/Http/Controllers/TaxonomyController.php
@@ -60,7 +60,6 @@ class TaxonomyController extends Controller
     public function getTaxables(Request $request)
     {
         $params = $request->all();
-        //        dd($params);
         $term = Term::where('slug', $params['term'])->first();
 
         if (!isset($term->id)) {
@@ -68,7 +67,6 @@ class TaxonomyController extends Controller
         }
 
         $taxonomy = Taxonomy::where('term_id', $term->id);
-//        dd($taxonomy->get());
 
 //        $taxonomy = Taxonomy::where('taxonomy', 'tags');
 
@@ -78,8 +76,6 @@ class TaxonomyController extends Controller
 //        }
 
         $taxables = Taxable::whereIn('taxonomy_id', $taxonomy->pluck('id'));
-//        dd($taxonomy->pluck('id'));
-//        dd($taxables->get());
 
         if ($params['model'] != null) {
             $taxables = $taxables->where('taxable_type', 'like', '%'.$params['model']);
@@ -88,7 +84,6 @@ class TaxonomyController extends Controller
         $taxableCollection = collect($taxables->orderBy('taxable_type')->orderBy('taxable_id')->get())->map(function (Taxable $taxable) use ($taxonomy) {
             $model = app($taxable->taxable_type);
             $data = $model::where('id', $taxable->taxable_id)->first();
-//            dd($data);
 
             return [
                 'type'              => Str::lower(Str::afterLast($taxable->taxable_type, '\\')),
@@ -112,14 +107,12 @@ class TaxonomyController extends Controller
             ],
         ];
 
-        //        dd($taxableCollection->groupBy('type'));
 
         return response()->json($data);
     }
 
     public function saveTerms(Request $request)
     {
-//        dd($request);
 
         $term = $request->get('term');
         $taxonomy = $request->get('taxonomy');
@@ -130,7 +123,6 @@ class TaxonomyController extends Controller
             $parent_id = isset($parent['parent_id']) ? $parent['parent_id'] : 0;
         }
 
-//        dd($parent_id);
         $tax = isset($taxonomy['taxonomy']) ? $taxonomy['taxonomy'] : $taxonomy;
 
         TaxonomyHelper::createTaxables($term, $tax, $parent_id);

--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -60,7 +60,6 @@ class WikiController extends Controller
         $total = $wikidata->total();
         $offset = ($page - 1) * $perPage;
 
-        //dd($wikidata->toSql());
 
         $wiki = $wikidata->getCollection()->map(function (Wiki $wiki) {
             $model = $wiki->wikiable_type;
@@ -140,7 +139,6 @@ class WikiController extends Controller
 
     public function show($slug)
     {
-        //        dd($slug);
 
         $wiki = Wiki::where('slug', '=', $slug)->first();
 
@@ -195,7 +193,6 @@ class WikiController extends Controller
 
     public function store(Request $request)
     {
-        //        dd($request->all());
         $parent = $request->get('parent_id');
         $parent_id = $parent['id'] ?? 0;
 
@@ -205,12 +202,10 @@ class WikiController extends Controller
             'sign_in_only' => 0,
             'published'    => 1]);
 
-//        dd($parent_id);
 
         if ($request->get('categories')) {
             //            $taxonomy = $request->get('taxonomy');
             //            $taxonomy = $taxonomy['taxonomy'];
-            //            //            dd('hm');
             //            $page->addCategories($request->get('categories'), $taxonomy);
 
             foreach ($request->get('categories') as $term) {
@@ -244,7 +239,6 @@ class WikiController extends Controller
 
     public function update(Request $request, $slug)
     {
-//                dd('update', $request->all(), $slug);
 
         //
         //        $wiki = $request->all();
@@ -322,13 +316,11 @@ class WikiController extends Controller
 
     public function storeCategory(Request $request)
     {
-        // dd($request);
 
         $term = Term::firstOrCreate(['title' => $request->get('term')]);
 
         $taxonomy = Taxonomy::firstOrNew(['taxonomy' => 'wiki', 'term_id' => $term->id]);
         $parent = $request->get('parent');
-//        dd($parent);
 
         if ($parent['parent_id']) {
             $taxonomy->parent_id = $parent['parent_id'];
@@ -344,14 +336,12 @@ class WikiController extends Controller
 
     public function updateCategory(Request $request, $slug)
     {
-//         dd($request);
 
         $termNew = $request->get('category');
         $termOld = $request->get('old');
         $parent = $request->get('parent');
         $title = $request->get('term');
 
-//        dd($parent);
 
         $term = Term::find($termNew['term']['id']);
         if ($term->title != $termOld['term']['title']) {
@@ -362,7 +352,6 @@ class WikiController extends Controller
 
         $taxonomy = Taxonomy::where('term_id', $term->id)->where('taxonomy', 'wiki')->first();
 //        $parent = $termNew['parent'];
-        //        dd($parent);
 
         if ($parent['parent_id']) {
             $taxonomy->parent_id = $parent['parent_id'];
@@ -373,7 +362,6 @@ class WikiController extends Controller
         }
         $taxonomy->update();
 
-//        dd($taxonomy);
         return response()->json(['message' => __('messages.wiki.category_updated'), 'slugchange' => $term->title != $termOld['term']['title'], 'term'=> $term, 'taxonomy' => $taxonomy]);
     }
 }


### PR DESCRIPTION
Removed 72 lines of commented dd(), var_dump(), and print_r() statements from PHP controllers for cleaner codebase.

Files cleaned:
- CommonController.php
- EventController.php
- WikiController.php
- TaxonomyController.php
- RelateableController.php
- DataTable/*.php (multiple files)

Note: JavaScript console.log cleanup deferred to separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced taxonomy data handling to correctly process both string and array formats, improving data validation robustness.

* **Chores**
  * Removed development debug statements across multiple controller modules for improved code cleanliness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->