### PR TITLE
fix: Add authorization to CollectionController

### DIFF
--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -67,6 +67,9 @@ class CollectionController extends Controller
     // Upload media to a collection
     public function uploadMedia(Request $request, Collection $collection)
     {
+        // Authorization check - only owner or admin can upload
+        $this->authorize('uploadMedia', $collection);
+
         $request->validate([
             'files'      => 'required|array', // Ensure files is an array
             'files.*'    => 'file|mimes:jpg,jpeg,png,gif|max:2048', // Validate each file
@@ -115,8 +118,13 @@ class CollectionController extends Controller
             'caption' => 'required|string|max:255',
         ]);
 
-        // Find the media item and update its caption
+        // Find the media item
         $media = Media::findOrFail($mediaId);
+
+        // Get the collection that owns this media and check authorization
+        $collection = Collection::findOrFail($media->model_id);
+        $this->authorize('update', $collection);
+
         $media->setCustomProperty('caption', $request->input('caption'));
         $media->save();
 

--- a/app/Policies/CollectionPolicy.php
+++ b/app/Policies/CollectionPolicy.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Collection;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class CollectionPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any collections.
+     */
+    public function viewAny(?User $user): bool
+    {
+        return true; // Collections are publicly viewable
+    }
+
+    /**
+     * Determine whether the user can view the collection.
+     */
+    public function view(?User $user, Collection $collection): bool
+    {
+        return true; // Collections are publicly viewable
+    }
+
+    /**
+     * Determine whether the user can create collections.
+     */
+    public function create(User $user): bool
+    {
+        return true; // Any authenticated user can create collections
+    }
+
+    /**
+     * Determine whether the user can update the collection.
+     */
+    public function update(User $user, Collection $collection): bool
+    {
+        // Owner or admin can update
+        return $user->id === $collection->user_id || $user->can('manage-posts');
+    }
+
+    /**
+     * Determine whether the user can delete the collection.
+     */
+    public function delete(User $user, Collection $collection): bool
+    {
+        // Owner or admin can delete
+        return $user->id === $collection->user_id || $user->can('manage-posts');
+    }
+
+    /**
+     * Determine whether the user can upload media to the collection.
+     */
+    public function uploadMedia(User $user, Collection $collection): bool
+    {
+        // Owner or admin can upload media
+        return $user->id === $collection->user_id || $user->can('manage-posts');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -14,7 +14,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        \App\Models\Collection::class => \App\Policies\CollectionPolicy::class,
     ];
 
     /**


### PR DESCRIPTION
Security fixes:
- Create CollectionPolicy for proper authorization
- Add authorization check to uploadMedia() - only owner/admin
- Add authorization check to updateMediaCaption() - only owner/admin
- Register policy in AuthServiceProvider

Previously any authenticated user could:
- Upload media to any collection
- Update captions on any media