### PR TITLE
Security: Add admin role authorization to menu management

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -11,6 +11,22 @@ use Illuminate\Support\Facades\Auth;
 class MenuController extends Controller
 {
     /**
+     * Create a new controller instance.
+     * Admin methods are protected by role check.
+     */
+    public function __construct()
+    {
+        // These methods require admin role
+        $this->middleware(function ($request, $next) {
+            $user = $request->user();
+            if (!$user || !$user->hasRole('admin')) {
+                return response()->json(['message' => 'Unauthorized - Admin role required'], 403);
+            }
+            return $next($request);
+        })->only(['index', 'store', 'update', 'destroy', 'getItems', 'addItem', 'updateItem', 'deleteItem', 'reorderItems']);
+    }
+
+    /**
      * Get menu by location (for frontend consumption).
      */
     public function getByLocation(string $location): JsonResponse


### PR DESCRIPTION
Fixed security issue where any authenticated user could manage menus. Added constructor middleware to require admin role for:
- index, store, update, destroy (menu CRUD)
- getItems, addItem, updateItem, deleteItem, reorderItems (item management)

Public menu access (getByLocation, getBySlug) remains unrestricted for frontend consumption.